### PR TITLE
Improve the dsl for event repetition to handle stopping conditions

### DIFF
--- a/dsl.dhall
+++ b/dsl.dhall
@@ -1,100 +1,132 @@
 let Prelude = https://prelude.dhall-lang.org/v20.0.0/package.dhall
 let Schema = ./types.dhall
 
+let periodityToRepetitionPattern = \(sp : Schema.Periodicity) ->
+  { stops =
+    { never =
+        { frequency = sp
+        , stopCondition = Schema.StopRepitition.Never
+        }
+    , on = \(date : Date) -> 
+        { frequency = sp
+        , stopCondition = Schema.StopRepitition.StopOn date
+        }
+    , after = \(n : Natural) ->
+        { frequency = sp
+        , stopCondition = Schema.StopRepitition.StopAfter n
+        }
+    }
+  }
+
 let every = \(n : Natural) ->
-  { days = Schema.Periodicity.Daily n
+  { days = 
+    periodityToRepetitionPattern 
+      (Schema.Periodicity.Daily n
+      )
   , weeks =
     { on = \(days : List Schema.DayOfWeek) ->
-      Schema.Periodicity.Weekly (
-        { n = n
-        , daysOfTheWeek = days
-        }
-      )
+      periodityToRepetitionPattern 
+        ( Schema.Periodicity.Weekly 
+          ( { n = n
+            , daysOfTheWeek = days
+            }
+          )
+        )
     }
   , months = 
     { onCalendarDays = \(days : List Natural) ->
-      Schema.Periodicity.MonthlyOn (
-        Schema.MonthlyPeridiocity.OnDays 
-          { nMonthly = n
-          , daysOfTheMonth = days
-          }  
-      )
+      periodityToRepetitionPattern
+        ( Schema.Periodicity.MonthlyOn
+          ( Schema.MonthlyPeridiocity.OnDays 
+            { nMonthly = n
+            , daysOfTheMonth = days
+            }
+          )
+        )
     , on =
       { first =
         { week = 
           { on = \(days : List Schema.DayOfWeek) ->
-            Schema.Periodicity.MonthlyOn (
-              Schema.MonthlyPeridiocity.OnFirst 
-                { nMonthly = n
-                , occurrence = 1
-                , daysOfTheWeek = days 
-                }
-            )
-
+            periodityToRepetitionPattern
+              ( Schema.Periodicity.MonthlyOn 
+                ( Schema.MonthlyPeridiocity.OnFirst 
+                  { nMonthly = n
+                  , occurrence = 1
+                  , daysOfTheWeek = days 
+                  }
+                ) 
+              )
           }
         }
       , second =
         { week = 
           { on = \(days : List Schema.DayOfWeek) ->
-            Schema.Periodicity.MonthlyOn (
-              Schema.MonthlyPeridiocity.OnFirst 
-                { nMonthly = n
-                , occurrence = 2
-                , daysOfTheWeek = days 
-                }
-            )
-
+            periodityToRepetitionPattern
+              ( Schema.Periodicity.MonthlyOn 
+                ( Schema.MonthlyPeridiocity.OnFirst 
+                  { nMonthly = n
+                  , occurrence = 2
+                  , daysOfTheWeek = days 
+                  }
+                ) 
+              )
           }
         }
       , third =
         { week = 
           { on = \(days : List Schema.DayOfWeek) ->
-            Schema.Periodicity.MonthlyOn (
-              Schema.MonthlyPeridiocity.OnFirst 
-                { nMonthly = n
-                , occurrence = 3
-                , daysOfTheWeek = days 
-                }
-            )
-
+            periodityToRepetitionPattern
+              ( Schema.Periodicity.MonthlyOn 
+                ( Schema.MonthlyPeridiocity.OnFirst 
+                  { nMonthly = n
+                  , occurrence = 3
+                  , daysOfTheWeek = days 
+                  }
+                ) 
+              )
           }
         }
       , fourth =
         { week = 
           { on = \(days : List Schema.DayOfWeek) ->
-            Schema.Periodicity.MonthlyOn (
-              Schema.MonthlyPeridiocity.OnFirst 
-                { nMonthly = n
-                , occurrence = 4
-                , daysOfTheWeek = days 
-                }
-            )
-
+            periodityToRepetitionPattern
+              ( Schema.Periodicity.MonthlyOn 
+                ( Schema.MonthlyPeridiocity.OnFirst 
+                  { nMonthly = n
+                  , occurrence = 4
+                  , daysOfTheWeek = days 
+                  }
+                ) 
+              )
           }
         }
       , secondToLast =
         { week = 
           { on = \(days : List Schema.DayOfWeek) ->
-            Schema.Periodicity.MonthlyOn (
-              Schema.MonthlyPeridiocity.OnLast 
-                { nMonthly = n
-                , occurrence = 2
-                , daysOfTheWeek = days 
-                }
-            )
+            periodityToRepetitionPattern
+              ( Schema.Periodicity.MonthlyOn 
+                ( Schema.MonthlyPeridiocity.OnLast 
+                  { nMonthly = n
+                  , occurrence = 2
+                  , daysOfTheWeek = days 
+                  }
+                ) 
+              )
 
           }
         }
       , last =
         { week = 
           { on = \(days : List Schema.DayOfWeek) ->
-            Schema.Periodicity.MonthlyOn (
-              Schema.MonthlyPeridiocity.OnLast 
-                { nMonthly = n
-                , occurrence = 1
-                , daysOfTheWeek = days 
-                }
-            )
+            periodityToRepetitionPattern
+              ( Schema.Periodicity.MonthlyOn 
+                ( Schema.MonthlyPeridiocity.OnLast 
+                  { nMonthly = n
+                  , occurrence = 1
+                  , daysOfTheWeek = days 
+                  }
+                ) 
+              )
           }
         }
       }
@@ -103,8 +135,8 @@ let every = \(n : Natural) ->
 
 in 
   { every = every
-  , stuff = (every 3).months.onCalendarDays [1, 2, 3] : Schema.Periodicity
-  , stuff2 = (every 2).months.on.first.week.on [Schema.DayOfWeek.Monday, Schema.DayOfWeek.Tuesday] : Schema.Periodicity
-  , stuff3 = (every 3).days : Schema.Periodicity
-  , stuff4 = (every 2).weeks.on [Schema.DayOfWeek.Friday, Schema.DayOfWeek.Saturday]
+  , stuff =  ((every 3).months.onCalendarDays [1, 2, 3]).stops.never : Schema.RepetitionPattern
+  , stuff2 = ((every 2).months.on.first.week.on [Schema.DayOfWeek.Monday, Schema.DayOfWeek.Tuesday]).stops.never : Schema.RepetitionPattern
+  , stuff3 = ((every 3).days).stops.never : Schema.RepetitionPattern
+  , stuff4 = ((every 2).weeks.on [Schema.DayOfWeek.Friday, Schema.DayOfWeek.Saturday]).stops.never : Schema.RepetitionPattern
   }

--- a/events/advice-cafe-01JCE0S0T214Z8FQZ8FMMDJWAJ/event.dhall
+++ b/events/advice-cafe-01JCE0S0T214Z8FQZ8FMMDJWAJ/event.dhall
@@ -11,11 +11,7 @@ in
     [ "A drop-in session with friendly advisors who can provide help and support when needed. Free energy advice and emergency food support available. ."
     ]
   , place = Schema.Place.Venue lowerGreenCommunityCentre
-  , repetition =
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Wednesday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Wednesday]).stops.never
   , eventType = None Schema.EventType
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/art-and-drawing-club-for-adults-01JBYNRJZX5XBTCR06R9ZDMEV7/event.dhall
+++ b/events/art-and-drawing-club-for-adults-01JBYNRJZX5XBTCR06R9ZDMEV7/event.dhall
@@ -13,11 +13,7 @@ in
     , "Light refreshments will be available."
     ]
   , place = Schema.Place.Venue esherLibrary
-  , repetition =
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Wednesday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Wednesday]).stops.never
   , eventType = Some Schema.EventType.VisualArtsEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/ballroom-jive-rock-and-roll-plus-stroll-01JCVS3BQH8WW66PS33QRAJFBF/event.dhall
+++ b/events/ballroom-jive-rock-and-roll-plus-stroll-01JCVS3BQH8WW66PS33QRAJFBF/event.dhall
@@ -12,11 +12,7 @@ in
     , "7pm - 8pm - Strolling. 8:15pm - 10:30pm - Jive and Rock and Roll!"
     ]
   , place = Schema.Place.Venue hershamSportsAndSocialClub
-  , repetition = 
-    Some 
-      { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Wednesday]
-      , stopCondition = Schema.StopRepitition.Never
-      }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Wednesday]).stops.never
   , eventType = Some Schema.EventType.SocialEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/bingo-01JCVS3BQH8WW66PS33QRAJFBE/event.dhall
+++ b/events/bingo-01JCVS3BQH8WW66PS33QRAJFBE/event.dhall
@@ -11,11 +11,7 @@ in
     [ "A hugely popular bingo night with bingo lovers new and old."
     ]
   , place = Schema.Place.Venue hershamSportsAndSocialClub
-  , repetition = 
-    Some 
-      { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Wednesday]
-      , stopCondition = Schema.StopRepitition.Never
-      }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Wednesday]).stops.never
   , eventType = Some Schema.EventType.SocialEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/country-music-live-01JD0VXT34BF6P6BAH7SRVBYEZ/event.dhall
+++ b/events/country-music-live-01JD0VXT34BF6P6BAH7SRVBYEZ/event.dhall
@@ -11,11 +11,7 @@ in
     [ "Pop along for an evening of country music played live every month."
     ]
   , place = Schema.Place.Venue hershamSportsAndSocialClub
-  , repetition = 
-    Some 
-      { frequency = (dsl.every 1).months.on.second.week.on [ Schema.DayOfWeek.Friday ]
-      , stopCondition = Schema.StopRepitition.Never
-      }
+  , repetition = Some ((dsl.every 1).months.on.second.week.on [ Schema.DayOfWeek.Friday ]).stops.never
   , eventType = Some Schema.EventType.SocialEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/fun-saints-play-group-01JD5ZPZ2P426ER1BKKG52VVRG/event.dhall
+++ b/events/fun-saints-play-group-01JD5ZPZ2P426ER1BKKG52VVRG/event.dhall
@@ -12,11 +12,7 @@ in
     , "There is a charge of £2.00 per child."
     ]
   , place = Schema.Place.Venue allSaintsWeston
-  , repetition = 
-    Some 
-      { frequency = (dsl.every 1).weeks.on [ Schema.DayOfWeek.Monday ]
-      , stopCondition = Schema.StopRepitition.Never
-      }
+  , repetition = Some ((dsl.every 1).weeks.on [ Schema.DayOfWeek.Monday ]).stops.never
   , eventType = Some Schema.EventType.ChildrensEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/parish-communion-01JCEFP6EYW8ZF83YGZE1CPQYQ/event.dhall
+++ b/events/parish-communion-01JCEFP6EYW8ZF83YGZE1CPQYQ/event.dhall
@@ -12,11 +12,7 @@ in
     , "On the other Sundays of the month, the service lasts for 70 minutes. There are four, usually traditional, hymns led by a choir. Children and young people are welcome and will go off to their teaching groups after the gathering prayer and return for communion."
     ]
   , place = Schema.Place.Venue christChurchEsher
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [ Schema.DayOfWeek.Sunday ]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [ Schema.DayOfWeek.Sunday ]).stops.never
   , eventType = Some Schema.EventType.ReligiousEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/pebble-rhymetime-01JBYNRJZX5XBTCR06R9ZDMEV4/event.dhall
+++ b/events/pebble-rhymetime-01JBYNRJZX5XBTCR06R9ZDMEV4/event.dhall
@@ -13,11 +13,7 @@ in
     , "Rhymetimes are free and are a great opportunity for dads, mums, carers and children to make new friends in a relaxed setting."
     ]
   , place = Schema.Place.Venue esherLibrary
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Thursday, Schema.DayOfWeek.Saturday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Thursday, Schema.DayOfWeek.Saturday]).stops.never
   , eventType = Some Schema.EventType.ChildrensEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/pebble-rhymetime-01JCVW56WPJKFVG6M5XH33YP1V/event.dhall
+++ b/events/pebble-rhymetime-01JCVW56WPJKFVG6M5XH33YP1V/event.dhall
@@ -13,11 +13,7 @@ in
     , "Rhymetimes are free and are a great opportunity for dads, mums, carers and children to make new friends in a relaxed setting."
     ]
   , place = Schema.Place.Venue hershamLibrary
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]).stops.never
   , eventType = Some Schema.EventType.ChildrensEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/rock-n-roll-01JD0WA0YKF4RV6EEK5FBGAXHM/event.dhall
+++ b/events/rock-n-roll-01JD0WA0YKF4RV6EEK5FBGAXHM/event.dhall
@@ -11,11 +11,7 @@ in
     [ "A monthly evening of Rock 'n Roll."
     ]
   , place = Schema.Place.Venue hershamSportsAndSocialClub
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).months.on.fourth.week.on [Schema.DayOfWeek.Friday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).months.on.fourth.week.on [Schema.DayOfWeek.Friday]).stops.never
   , eventType = Some Schema.EventType.MusicEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/storytime-01JBYNRJZX5XBTCR06R9ZDMEV6/event.dhall
+++ b/events/storytime-01JBYNRJZX5XBTCR06R9ZDMEV6/event.dhall
@@ -13,11 +13,7 @@ in
     , "Sessions are free and generally last 30 minutes."
     ]
   , place = Schema.Place.Venue esherLibrary
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]).stops.never
   , eventType = Some Schema.EventType.ChildrensEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/storytime-01JCVW8ACPTJW7HHZJMCWD1KNR/event.dhall
+++ b/events/storytime-01JCVW8ACPTJW7HHZJMCWD1KNR/event.dhall
@@ -13,11 +13,7 @@ in
     , "Sessions are free and generally last 30 minutes."
     ]
   , place = Schema.Place.Venue hershamLibrary
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]).stops.never
   , eventType = Some Schema.EventType.ChildrensEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/sunday-night-quiz-01JC0XYWX6WN43GKVRS6WM8YBH/event.dhall
+++ b/events/sunday-night-quiz-01JC0XYWX6WN43GKVRS6WM8YBH/event.dhall
@@ -13,11 +13,7 @@ in
     , "A great way to round off the weekend and beat those Sunday Night blues. Can't wait to see you all there!"
     ]
   , place = Schema.Place.Venue theBearHotelEsher
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Sunday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Sunday]).stops.never
   , eventType = Some Schema.EventType.SocialEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/the-surrey-blues-club-01JD0W3M4DHPX15SKJ5F31X679/event.dhall
+++ b/events/the-surrey-blues-club-01JD0W3M4DHPX15SKJ5F31X679/event.dhall
@@ -12,11 +12,7 @@ in
     [ "The Surrey Blues Club provides an opportunity for both listeners and players to enjoy classic blues every month."
     ]
   , place = Schema.Place.Venue hershamSportsAndSocialClub
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).months.on.first.week.on [Schema.DayOfWeek.Friday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).months.on.first.week.on [Schema.DayOfWeek.Friday]).stops.never
   , eventType = Some Schema.EventType.MusicEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/the-surrey-shadows-01JCVT505XM49F6HQD909YN35M/event.dhall
+++ b/events/the-surrey-shadows-01JCVT505XM49F6HQD909YN35M/event.dhall
@@ -12,11 +12,7 @@ in
     [ "The Surrey Shadows Club welcomes everyone to their musical evenings, whether you sing, play guitar, bass, keyboards or drums. We are extremely pleased to have Breakthru' continue as our Backing Band for the Surrey Shadows Club."
     ]
   , place = Schema.Place.Venue hershamSportsAndSocialClub
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).months.on.third.week.on [Schema.DayOfWeek.Friday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).months.on.third.week.on [Schema.DayOfWeek.Friday]).stops.never
   , eventType = Some Schema.EventType.MusicEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/thursday-tennis-drills-01JCDV9SAPKMJJ6663FFSQ2TFX/event.dhall
+++ b/events/thursday-tennis-drills-01JCDV9SAPKMJJ6663FFSQ2TFX/event.dhall
@@ -13,11 +13,7 @@ in
     , "The sessions are free for members but guests are welcome to come along for five taster sessions costing £5 each."
     ]
   , place = Schema.Place.Venue emberSportsClub
-  , repetition =
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Thursday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Thursday]).stops.never
   , eventType = Some Schema.EventType.SportsEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/tuesday-live-music-nights-01JCVRPRBF9CGV1PZS60AYX6G6/event.dhall
+++ b/events/tuesday-live-music-nights-01JCVRPRBF9CGV1PZS60AYX6G6/event.dhall
@@ -12,11 +12,7 @@ in
     [ "A live music night featuring solo acts, duos, trios and full bands and varied music genres."
     ]
   , place = Schema.Place.Venue hershamSportsAndSocialClub
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]).stops.never
   , eventType = Some Schema.EventType.MusicEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/tuesday-quiz-01JCVRPRBF9CGV1PZS60AYX6G7/event.dhall
+++ b/events/tuesday-quiz-01JCVRPRBF9CGV1PZS60AYX6G7/event.dhall
@@ -12,11 +12,7 @@ in
     [ "1st prize is a £50 voucher with rollover jackpot quesations. Food is served until 10pm."
     ]
   , place = Schema.Place.Venue theRoyalGeorgeHersham
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]
-        , stopCondition = Schema.StopRepitition.Never
-        }
+  , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]).stops.never
   , eventType = Some Schema.EventType.SocialEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = None Text

--- a/events/watercolour-workshop-for-adults-01JDJMFH48F31RKZGJR2C540HC/event.dhall
+++ b/events/watercolour-workshop-for-adults-01JDJMFH48F31RKZGJR2C540HC/event.dhall
@@ -10,11 +10,7 @@ in
   , id = "01J8FWH1S4TQWJGP4YGS5GZ7NH01JDJMFH48F31RKZGJR2C540HC"
   , content = Schema.Content.MarkdownContent ./event.md as Text
   , place = Schema.Place.Venue bluehouseArtSpace
-  , repetition = 
-      Some 
-        { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]
-        , stopCondition = Schema.StopRepitition.StopOn 2024-12-10
-        }
+  , repetition = Some (((dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]).stops.on 2024-12-10)
   , eventType = Some Schema.EventType.VisualArtsEvent
   , revisions = [] : List Schema.EventRevision
   , signupUrl = Some "https://parulofthesea.com/collections/workshops/products/watercolour-workshop-for-adults-tuesday-afternoons"

--- a/events/younger-babies-rhymetime-01JBYNRJZX5XBTCR06R9ZDMEV5/event.dhall
+++ b/events/younger-babies-rhymetime-01JBYNRJZX5XBTCR06R9ZDMEV5/event.dhall
@@ -13,11 +13,7 @@ in
       , "No booking is needed, just come along!"
       ]
     , place = Schema.Place.Venue esherLibrary
-    , repetition = 
-        Some 
-          { frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Saturday]
-          , stopCondition = Schema.StopRepitition.Never
-          }
+    , repetition = Some ((dsl.every 1).weeks.on [Schema.DayOfWeek.Saturday]).stops.never
     , eventType = Some Schema.EventType.ChildrensEvent
     , revisions = [] : List Schema.EventRevision
     , signupUrl = None Text

--- a/flake.lock
+++ b/flake.lock
@@ -63,11 +63,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1732489810,
-        "narHash": "sha256-MapcS15XewTfbESIsgs7YE4RGS70jVRiLqApefcnI1s=",
+        "lastModified": 1732622700,
+        "narHash": "sha256-qOJjwllsz4Czte460OfaIhB7C2AyOhFf+IqSGD9aDcw=",
         "owner": "Hereabout",
         "repo": "hereabout-mono",
-        "rev": "67753b5442bd3716be1ec22804034dbdf9058eb6",
+        "rev": "2e4e3ca7e4afdca66de287cb7f9b8ff2fcb00f80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The event repetition now produces a `RepetitionPattern` instead of a `Periodicity`.

This makes the generation of stopping conditions more convenient.

```dhall
{ frequency = (dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]
, stopCondition = Schema.StopRepitition.StopOn 2024-12-10
}
```

becomes

```dhall
(((dsl.every 1).weeks.on [Schema.DayOfWeek.Tuesday]).stops.on 2024-12-10)
```
